### PR TITLE
Speaker information email template

### DIFF
--- a/email-templates/speaker-information.md
+++ b/email-templates/speaker-information.md
@@ -1,0 +1,53 @@
+**Hi,**
+
+We are so glad to have you speaking at one of our events!
+
+Here is some practical information:
+
+**Event details**
+
+Host:
+
+Address: 
+
+Attendees: 
+
+Time: 
+
+Contact person:
+
+Food and drinks will be served during the event, vegan and non-alcoholic alternatives are always available
+
+**Code of conduct**
+
+All speakers, hosts and participants are expected to follow our Code of Conduct: https://github.com/stockholm-react-js/governance/blob/master/CODE_OF_CONDUCT.md
+
+It is especially important for speakers to make sure that their content follow these guidelines. *Please be extra mindful about what jokes you include and about your graphic elements.*
+
+If you experience any behaviour before, during or after the event that violates our CoC, please let us know in person or online, we are here to help!
+
+**Speaker information**
+
+Speakers welcome for setup or rehearsal from earliest:
+
+Q&A: No, unless you explicitly ask for it
+
+Highest projector resolution:
+
+Projector connections: 
+
+Microphone: [Yes / No]
+
+Recording: [Yes, please contact the organisers if you do not wish your talk to be posted online. / No]
+
+Speakers are encouraged but not required to show up a bit earlier to set up and make sure the presentation is working as intended.
+
+For main talks we usually do not enforce time slots rigorously. Exceptions are made if talks are running very long or if the event schedule requires it so aim to stick to your allotted time.
+
+For lightning talks we usually try to enforce time slots semi-rigorously. Keep them to 10 minutes and be prepared to quickly conclude the talk if you happen to run over time (we will always give you a minute to finish up).
+
+We hope this answers some of the questions you might have had, don’t hesitate to get in touch if something went unanswered or if we can help in any way.
+
+**All the best,**
+
+Stockholm ReactJS Organisers via X


### PR DESCRIPTION
A template to fill out and email to speakers before events.

We also want to have a Speaker information-document that can be linked to here on GitHub or on the website, that is mainly aimed at people interested in speaking. We might want to automate this email somehow in the future.

For now I thought I'd just go ahead and post this since I had already written the email for an event. :)